### PR TITLE
Konflikt mit Textile-Addon

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -9,3 +9,7 @@ page:
     pjax: true
     subpages:
         profiles: { title: 'translate:profiles', perm: rex_markitup[profiles] }
+
+conflicts:
+    packages:
+        textile: *


### PR DESCRIPTION
Als Vorschlag, zur Vorbereitung für redaxo/redaxo#755.

Bedeutet aber: Wenn jemand das Textile-Addon installiert hat, und dann versucht markitup auf die nächste Version zu aktualisieren, bekommt er die Meldung, dass das nicht geht, da es nicht gleichzeitig mit textile installiert sein kann.
Wir müssten also mit Fragen zu der Thematik rechnen, da einige sicherlich nicht wissen, dass in markitup in R5 schon der Parser dabei ist.

So vermeiden wir aber auch frühzeitig, dass es irgendwann Konflikte gibt, wenn hier der Parser aktualisiert wird, und jemand dann noch ein altes textile-Addon installiert hat.